### PR TITLE
Feature/initial add

### DIFF
--- a/check_cdap_program/bin/check_cdap_program
+++ b/check_cdap_program/bin/check_cdap_program
@@ -153,7 +153,7 @@ fi
 #         comma-separated program specifications
 
 # Confirm that curl is installed
-if [ ! "$(which curl)" != "" ] ; then
+if [[ ! $(which curl) ]] ; then
   echo "ERROR: curl must be installed and present in \$PATH" 
   usage
   exit ${UNKNOWN}
@@ -192,6 +192,8 @@ function get_program_status {
   local __progtype=${2}
   local __status_url="${OPT_URI}/${API_VERSION}/namespaces/${OPT_NAMESPACE}"\
 "/apps/${__appname}/${__progtype}/${__flowname}/status"
+
+  # Prep and execute a curl request
   cdap_curl_request ${__status_url}
 
   # Trim result to single status string
@@ -210,9 +212,7 @@ function get_program_status {
 function cdap_curl_request {
   local __url=${1}
   local __v_flag=''
-  if [ -n "${OPT_VERBOSE}" ]; then
-    __v_flag='-v'
-  fi
+  [[ ${OPT_VERBOSE} ]] && __v_flag='-v'
   local __resp=`curl ${__v_flag} -k -s -m ${OPT_TIMEOUT} -w ' %{http_code}' ${__url}`
   local __exitcode=$?
 
@@ -257,7 +257,7 @@ function process_result {
   local __status=${2}
 
   # Append to, or initialize, result message
-  if [ -z ${res_message} ] ; then
+  if [ -z "${res_message}" ] ; then
     res_message=${__program}=${__status}
   else
     res_message=${res_message},${__program}=${__status}
@@ -307,7 +307,7 @@ for __worker in "${__workers[@]}"; do
 done
 
 # Prepend result message with status string
-case $res_status in
+case ${res_status} in
   0)
     res_message="OK: ${res_message}"
     ;;
@@ -323,5 +323,5 @@ case $res_status in
 esac
 
 # Display result to user and exit
-echo $res_message
-exit $res_status
+echo ${res_message}
+exit ${res_status}


### PR DESCRIPTION
First cut of Nagios plugin to check CDAP program status.
- [x] usage mirrors the cli, ie `get flow status MyApp.MyFlow` => `-f MyApp.MyFlow`
- [ ] a couple of TODOs documented within to be addressed in subsequent PRs before this is public
  - [ ] more validation, add args for insecure and auth-token

```
# Check a program is running
$ ./check_cdap_program -u http://mycdap.example.com:10000 -s PurchaseHistory.UserProfileService
OK: PurchaseHistory.UserProfileService=RUNNING

# Can provide a list, comma-separated
$ ./check_cdap_program -u http://mycdap.example.com:10000 -s PurchaseHistory.UserProfileService,SportResults.UploadService
OK: PurchaseHistory.UserProfileService=RUNNING,SportResults.UploadService=RUNNING

# Can provide multiple program types
./check_cdap_program -u http://mycdap.example.com:10000 -s PurchaseHistory.UserProfileService,SportResults.UploadService -W DatasetWorkerApp.DataWriter
OK: PurchaseHistory.UserProfileService=RUNNING,SportResults.UploadService=RUNNING,DatasetWorkerApp.DataWriter=RUNNING

# Any single failure sets CRITICAL exit status
$ ./check_cdap_program -u http://mycdap.example.com:10000 -s PurchaseHistory.UserProfileService,SportResults.UploadService -W DatasetWorkerApp.DataWriter -f HelloWorld.WhoFlow
CRITICAL: HelloWorld.WhoFlow=STOPPED,PurchaseHistory.UserProfileService=RUNNING,SportResults.UploadService=RUNNING,DatasetWorkerApp.DataWriter=RUNNING

# Invalid programs treated as critical, and fails-fast
$ ./check_cdap_program -u http://mycdap.example.com:10000 -s PurchaseHistory.UserProfileService,SportResults.UploadService -W FakeApp.FakeWorkflow
CRITICAL: CDAP Endpoint not found 404: http://cdap-dev.cask.co:10000/v3/namespaces/default/apps/FakeApp/workers/FakeWorkflow/status

# unauthorized treated as unknown
$ ./check_cdap_program -u http://mycdap.example.com:10000 -s PurchaseHistory.UserProfileService
UNKNOWN: CDAP Authentication not currently supported: {"auth_uri":["http://<redacted>:10009/token"]} 401

# any unexpected http return code treated as unknown
$ ./check_cdap_program -u http://<invalid.uri>:10000 -s PurchaseHistory.UserProfileService
UNKNOWN: unexpected HTTP response code 000:  000

# Invalid args/Usage:
$ ./check_cdap_program 
ERROR: -u <uri> is required

Nagios-style plugin to check status of CDAP Programs

Requirements:
  curl

Usage: ./check_cdap_program [-hv] [-t timeout] -u <uri> [-n <namespace>] [-f <app.name>] 
         [-m <app.name>] [-s <app.name>] [-S <app.name>] [-w <app.name>]
         [-W <app.name>]

Options:
  -h            Usage info
  -u <uri>      CDAP Router endpoint to check
  -n <namespace>        CDAP Namespace to query
  -f <app.flows>        CDAP target Flow to check. Each Flow must be prepended
                        with the Application name and delimited with a period.
                        Multiple Application.Flow pairs can be specified as a
                        comma-separated list
  -m <app.mapreduce>    CDAP target MapReduce to check. Each MapReduce must be
                        prepended with the Application name and delimited with
                        a period. Multiple Application.MapReduce pairs can be
                        specified as a comma-separated list
  -s <app.services>     CDAP target Service to check. Each Service must be
                        prepended with the Application name and delimited with
                        a period. Multiple Application.Service pairs can be
                        specified as a comma-separated list
  -S <app.spark>        CDAP target Spark jobs to check. Each Spark job must be
                        prepended with the Application name and delimited with
                        a period. Multiple Application.Spark pairs can be
                        specified as a comma-separated list
  -w <app.workflows>    CDAP target Workflow to check. Each Workflow must be
                        prepended with the Application name and delimited with
                        a period. Multiple Application.Workflow pairs can be
                        specified as a comma-separated list
  -W <app.workers>      CDAP target Workers to check. Each Worker must be
                        prepended with the Application name and delimited with
                        a period. Multiple Application.Worker pairs can be
                        specified as a comma-separated list
  -t <timeout>      override default timeout (seconds)
  -v            verbose (debug) output

Example:
  ./check_cdap_program -u http://my.cdap.router.endpoint:10000 -n mynamespace -f MyApp.MyFlow
       -s MyApp.MyService1,MyApp.MyService2


```
