### PR TITLE
Feature/add token

### DIFF
--- a/check_cdap_program/bin/check_cdap_program
+++ b/check_cdap_program/bin/check_cdap_program
@@ -22,7 +22,7 @@ Nagios-style plugin to check status of CDAP Programs
 Requirements:
   curl
 
-Usage: $0 [-hvk] [-t timeout] -u <uri> [-n <namespace>] [-f <app.flow>] 
+Usage: $0 [-hvk] [-t timeout] -u <uri> [-n <namespace>] [-f <app.flow>]
          [-m <app.mapreduce>] [-s <app.service>] [-S <app.spark>]
          [-w <app.workflow>] [-W <app.worker>] [-T <token>]
 


### PR DESCRIPTION
- [x] support for `-T <access token>`
- [x] support for `-k` to turn off ssl cert verification

```
$ ./check_cdap_program -u http://[auth-enabled-cdap]:10000 -s PurchaseHistory.UserProfileService
UNKNOWN: CDAP Access Token required: {"auth_uri":["http://<redacted>:10009/token"]} 401

$ ./check_cdap_program -u http://[auth-enabled-cdap]:10000 -s PurchaseHistory.UserProfileService -T foo
UNKNOWN: Invalid CDAP Access Token: {"error":"invalid_token","error_description":"Invalid token signature.","auth_uri":["http://redacted:10009/token"]} 401

$ ./check_cdap_program -u http://[auth-enabled-cdap]:10000 -s PurchaseHistory.UserProfileService -T AgpkZXJlawDUj5W/9lPUr4vniVSK2/y9AUA3BmwR4a9NNhxj7rQv7f9Gd+c3MyAzhNXWIxuS0XKeyQ==
CRITICAL: CDAP Endpoint not found 404: http://<redacted>:10000/v3/namespaces/default/apps/PurchaseHistory/services/UserProfileService/status
```
