### PR TITLE
Feature/validate program args

### DIFF
--- a/check_cdap_program/bin/check_cdap_program
+++ b/check_cdap_program/bin/check_cdap_program
@@ -158,7 +158,6 @@ function validate_program_options {
   local __progname=''
   IFS=',' read -ra __prog_specs <<< "${__opt_val}"
   for __prog_spec in "${__prog_specs[@]}"; do
-  #  validate_program_spec ${__program}
     IFS='.' read __appname __progname <<< "${__prog_spec}"
     if [ -z ${__appname} ] || [ -z ${__progname} ] ; then
       echo "ERROR: Invalid program specification given: ${__opt_val}"
@@ -316,7 +315,6 @@ done
 # Confirm that curl is installed
 if [[ ! $(which curl) ]] ; then
   echo "ERROR: curl must be installed and present in \$PATH"
-  usage
   exit ${UNKNOWN}
 fi
 


### PR DESCRIPTION
- [x] validates that any given program argument is in the valid `App.Prog[,App.Prog ...]` format.
- [x] re-ordering to keep function definitions together, and move validation code below them (since validation now requires a function).  This makes the diff worse than it is... See the first commit for the only real changes.

```
$ ./check_cdap_program -u http://cdap:10000 -f app.prog,invalid
ERROR: Invalid program specification given: app.prog,invalid
...
<usage>
...
```
