### PR TITLE
Feature/support env vars

### DIFF
--- a/check_cdap_program/bin/check_cdap_program
+++ b/check_cdap_program/bin/check_cdap_program
@@ -31,7 +31,7 @@ Usage: $0 [-hvk] [-t timeout] -u <uri> [-n <namespace>] [T <token>]
          [-W <app.worker>[,<app.worker> ...]]
 
 Options:
-  -h                    Usage info
+  -h                    Usage information.
   -u <uri>              CDAP Router endpoint to check. Defaults to the
                         environment variable CHECK_CDAP_URI, else empty.
   -n <namespace>        CDAP Namespace to query. Defaults to the environment
@@ -66,12 +66,12 @@ Options:
                         a period. Multiple Application.Worker pairs can be
                         specified as a comma-separated list. Defaults to the
                         environment variable CHECK_CDAP_WORKERS, else empty.
-  -t <timeout>          override default timeout (seconds). Defaults to the
+  -t <timeout>          Override default timeout (seconds). Defaults to the
                         environment variable CHECK_CDAP_TIMEOUT, else 30.
   -T <token>            CDAP Access Token. Defaults to the environment variable
                         CHECK_CDAP_TOKEN, else empty.
   -k                    Disable SSL certification validation
-  -v                    verbose (debug) output
+  -v                    Verbose (debug) output.
 
 
 Examples:


### PR DESCRIPTION
- [x] adds support for reading from environment variables (args will take precedence in case of both)
- [x] renamed the internal variables to match the environment variable names
- [x] resultant formatting fixes and updated usage

```
$ CHECK_CDAP_PROGRAM_URI=http://<redacted>:10000 CHECK_CDAP_PROGRAM_FLOWS=SQSApp.SQSFlow CHECK_CDAP_PROGRAM_TOKEN='AgpkZXJlawDUj5W/9lPUr4vniVSK2/y9AUA3BmwR4a9NNhxj7rQv7f9Gd+c3MyAzhNXWIxuS0XKeyQ==' ./check_cdap_program 
OK: SQSApp.SQSFlow=RUNNING
```
