### PR TITLE
handle more error codes, default to localhost

### DIFF
--- a/nagios/check_cdap_program/bin/check_cdap_program
+++ b/nagios/check_cdap_program/bin/check_cdap_program
@@ -33,7 +33,8 @@ Usage: $0 [-hvk] [-t timeout] -u <uri> [-n <namespace>] [T <token>]
 Options:
   -h                    Usage information.
   -u <uri>              CDAP Router endpoint to check. Defaults to the
-                        environment variable CHECK_CDAP_URI, else empty.
+                        environment variable CHECK_CDAP_URI, else
+                        http://localhost:10000.
   -n <namespace>        CDAP Namespace to query. Defaults to the environment
                         variable CHECK_CDAP_NAMESPACE, else 'default'.
   -f <app.flow>         CDAP target Flow to check. Each Flow must be prepended
@@ -90,7 +91,7 @@ EOF
 
 # Option defaults
 OPT_VERBOSE=''
-CHECK_CDAP_URI=${CHECK_CDAP_URI}
+CHECK_CDAP_URI=${CHECK_CDAP_URI:-'http://localhost:10000'}
 CHECK_CDAP_NAMESPACE=${CHECK_CDAP_NAMESPACE:-default}
 CHECK_CDAP_FLOWS=${CHECK_CDAP_FLOWS}
 CHECK_CDAP_MAPREDUCES=${CHECK_CDAP_MAPREDUCES}
@@ -275,6 +276,14 @@ function cdap_curl_request {
     404)
       echo "CRITICAL: CDAP Endpoint not found ${__respcode}: ${__url}"
       exit ${CRITICAL}
+      ;;
+    000)
+      echo "UNKNOWN: CDAP Router appears to be down. HTTP response code ${__response}: ${__resp}"
+      exit ${UNKNOWN}
+      ;;
+    503)
+      echo "UNKNOWN: CDAP Master container not responding. HTTP response code ${__response}: ${__resp}"
+      exit ${UNKNOWN}
       ;;
     *)
       echo "UNKNOWN: unexpected HTTP response code ${__respcode}: ${__resp}"


### PR DESCRIPTION
A couple minor updates, imported from `check_cdap` plugin, to keep the plugins consistent
- [x] handle 000 and 503 error codes
- [x] default to localhost:10000
