### PR TITLE
accept namespace argument

### DIFF
--- a/nagios/check_cdap_program/bin/check_cdap_program
+++ b/nagios/check_cdap_program/bin/check_cdap_program
@@ -116,7 +116,7 @@ res_status=0
 res_message=''
 
 # Read in args
-while getopts "hvku:f:m:s:S:w:W:t:T:" opt; do
+while getopts "hvku:n:f:m:s:S:w:W:t:T:" opt; do
   case $opt in
     h)
       usage
@@ -127,6 +127,9 @@ while getopts "hvku:f:m:s:S:w:W:t:T:" opt; do
       ;;
     u)
       CHECK_CDAP_URI=${OPTARG}
+      ;;
+    n)
+      CHECK_CDAP_NAMESPACE=${OPTARG}
       ;;
     f)
       CHECK_CDAP_FLOWS=${OPTARG}


### PR DESCRIPTION
actually accept the `-n namespace` argument as advertised

```
# ./check_cdap_program -u http://`hostname`:10000 -n dw1 -f PurchaseHistory.PurchaseFlow
OK: PurchaseHistory.PurchaseFlow=RUNNING
```
